### PR TITLE
fix(iteritems): replace with `items` instead (and other fixes for consistency)

### DIFF
--- a/cron/config.sls
+++ b/cron/config.sls
@@ -8,7 +8,7 @@
 
 cron.{{ task }}:
   cron.{{ task_options.type|default('present') }}:
-    - name: '{{ task_options.name }}'
+    - name: {{ task_options.name }}
     {%- if 'user' in task_options %}
     - user: {{ task_options.user|default('root') }}
     {%- endif %}
@@ -35,7 +35,7 @@ cron.{{ task }}:
     {%- endif %}
     - identifier: '{{ task }}'
     {%- if 'comment' in task_options %}
-    - comment: '{{ task_options.comment }}'
+    - comment: {{ task_options.comment }}
     {%- endif %}
 {%- endfor %}
 {%- endif %}

--- a/cron/config.sls
+++ b/cron/config.sls
@@ -4,7 +4,7 @@
 {% from "cron/map.jinja" import cron_settings with context %}
 
 {% if 'tasks' in cron_settings %}
-{% for task,task_options in cron_settings.tasks.iteritems() %}
+{% for task,task_options in cron_settings.tasks.items() %}
 
 cron.{{ task }}:
     cron.{{ task_options.type|default('present') }}:

--- a/cron/config.sls
+++ b/cron/config.sls
@@ -7,35 +7,35 @@
 {% for task,task_options in cron_settings.tasks.items() %}
 
 cron.{{ task }}:
-    cron.{{ task_options.type|default('present') }}:
-        - name: '{{ task_options.name }}'
-        {% if 'user' in task_options %}
-        - user: {{ task_options.user|default('root') }}
-        {% endif %}
-        {% if 'minute' in task_options %}
-        - minute: '{{ task_options.minute }}'
-        {% endif %}
-        {% if 'hour' in task_options %}
-        - hour: '{{ task_options.hour }}'
-        {% endif %}
-        {% if 'daymonth' in task_options %}
-        - daymonth: '{{ task_options.daymonth }}'
-        {% endif %}
-        {% if 'month' in task_options %}
-        - month: '{{ task_options.month }}'
-        {% endif %}
-        {% if 'dayweek' in task_options %}
-        - dayweek: '{{ task_options.dayweek }}'
-        {% endif %}
-        {% if 'commented' in task_options and task_options.commented %}
-        - commented: True
-        {% endif %}
-        {% if 'special' in task_options %}
-        - special: '{{ task_options.special }}'
-        {% endif %}
-        - identifier: '{{ task }}'
-        {% if 'comment' in task_options %}
-        - comment: '{{ task_options.comment }}'
-        {% endif %}
+  cron.{{ task_options.type|default('present') }}:
+    - name: '{{ task_options.name }}'
+    {% if 'user' in task_options %}
+    - user: {{ task_options.user|default('root') }}
+    {% endif %}
+    {% if 'minute' in task_options %}
+    - minute: '{{ task_options.minute }}'
+    {% endif %}
+    {% if 'hour' in task_options %}
+    - hour: '{{ task_options.hour }}'
+    {% endif %}
+    {% if 'daymonth' in task_options %}
+    - daymonth: '{{ task_options.daymonth }}'
+    {% endif %}
+    {% if 'month' in task_options %}
+    - month: '{{ task_options.month }}'
+    {% endif %}
+    {% if 'dayweek' in task_options %}
+    - dayweek: '{{ task_options.dayweek }}'
+    {% endif %}
+    {% if 'commented' in task_options and task_options.commented %}
+    - commented: True
+    {% endif %}
+    {% if 'special' in task_options %}
+    - special: '{{ task_options.special }}'
+    {% endif %}
+    - identifier: '{{ task }}'
+    {% if 'comment' in task_options %}
+    - comment: '{{ task_options.comment }}'
+    {% endif %}
 {% endfor %}
 {% endif %}

--- a/cron/config.sls
+++ b/cron/config.sls
@@ -1,41 +1,41 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
-{% from "cron/map.jinja" import cron_settings with context %}
+{%- from "cron/map.jinja" import cron_settings with context %}
 
-{% if 'tasks' in cron_settings %}
-{% for task,task_options in cron_settings.tasks.items() %}
+{%- if 'tasks' in cron_settings %}
+{%- for task,task_options in cron_settings.tasks.items() %}
 
 cron.{{ task }}:
   cron.{{ task_options.type|default('present') }}:
     - name: '{{ task_options.name }}'
-    {% if 'user' in task_options %}
+    {%- if 'user' in task_options %}
     - user: {{ task_options.user|default('root') }}
-    {% endif %}
-    {% if 'minute' in task_options %}
+    {%- endif %}
+    {%- if 'minute' in task_options %}
     - minute: '{{ task_options.minute }}'
-    {% endif %}
-    {% if 'hour' in task_options %}
+    {%- endif %}
+    {%- if 'hour' in task_options %}
     - hour: '{{ task_options.hour }}'
-    {% endif %}
-    {% if 'daymonth' in task_options %}
+    {%- endif %}
+    {%- if 'daymonth' in task_options %}
     - daymonth: '{{ task_options.daymonth }}'
-    {% endif %}
-    {% if 'month' in task_options %}
+    {%- endif %}
+    {%- if 'month' in task_options %}
     - month: '{{ task_options.month }}'
-    {% endif %}
-    {% if 'dayweek' in task_options %}
+    {%- endif %}
+    {%- if 'dayweek' in task_options %}
     - dayweek: '{{ task_options.dayweek }}'
-    {% endif %}
-    {% if 'commented' in task_options and task_options.commented %}
+    {%- endif %}
+    {%- if 'commented' in task_options and task_options.commented %}
     - commented: True
-    {% endif %}
-    {% if 'special' in task_options %}
+    {%- endif %}
+    {%- if 'special' in task_options %}
     - special: '{{ task_options.special }}'
-    {% endif %}
+    {%- endif %}
     - identifier: '{{ task }}'
-    {% if 'comment' in task_options %}
+    {%- if 'comment' in task_options %}
     - comment: '{{ task_options.comment }}'
-    {% endif %}
-{% endfor %}
-{% endif %}
+    {%- endif %}
+{%- endfor %}
+{%- endif %}

--- a/cron/init.sls
+++ b/cron/init.sls
@@ -2,6 +2,6 @@
 # vim: ft=sls
 
 include:
-    - cron.install
-    - cron.config
-    - cron.service
+  - cron.install
+  - cron.config
+  - cron.service

--- a/cron/install.sls
+++ b/cron/install.sls
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
-{% from "cron/map.jinja" import cron_settings with context %}
+{%- from "cron/map.jinja" import cron_settings with context %}
 
 cron.install:
   pkg.installed:

--- a/cron/install.sls
+++ b/cron/install.sls
@@ -4,5 +4,5 @@
 {% from "cron/map.jinja" import cron_settings with context %}
 
 cron.install:
-    pkg.installed:
-        - name: {{ cron_settings.pkg }}
+  pkg.installed:
+    - name: {{ cron_settings.pkg }}

--- a/cron/map.jinja
+++ b/cron/map.jinja
@@ -2,23 +2,23 @@
 # vim: ft=jinja
 
 {% set os_family_map = salt['grains.filter_by']({
-        'RedHat': {
-            'pkg': 'cronie',
-            'service': 'crond',
-        },
-        'Suse': {
-            'pkg': 'cronie',
-            'service': 'cron',
-        },
-        'Debian': {
-            'pkg': 'cron',
-            'service': 'cron',
-        },
+    'RedHat': {
+      'pkg': 'cronie',
+      'service': 'crond',
+    },
+    'Suse': {
+      'pkg': 'cronie',
+      'service': 'cron',
+    },
+    'Debian': {
+      'pkg': 'cron',
+      'service': 'cron',
+    },
   }, grain='os_family', merge=salt['pillar.get']('cron:lookup')) %}
 
 {% set cron_settings = salt['pillar.get'](
-        'cron',
-        default=os_family_map,
-        merge=True
-    )
+    'cron',
+    default=os_family_map,
+    merge=True
+  )
 %}

--- a/cron/map.jinja
+++ b/cron/map.jinja
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: ft=jinja
 
-{% set os_family_map = salt['grains.filter_by']({
+{%- set os_family_map = salt['grains.filter_by']({
     'RedHat': {
       'pkg': 'cronie',
       'service': 'crond',
@@ -16,7 +16,7 @@
     },
   }, grain='os_family', merge=salt['pillar.get']('cron:lookup')) %}
 
-{% set cron_settings = salt['pillar.get'](
+{%- set cron_settings = salt['pillar.get'](
     'cron',
     default=os_family_map,
     merge=True

--- a/cron/service.sls
+++ b/cron/service.sls
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
-{% from "cron/map.jinja" import cron_settings with context %}
+{%- from "cron/map.jinja" import cron_settings with context %}
 
 cron.service:
-{% if 'enabled' not in cron_settings or ( 'enabled' in cron_settings and cron_settings.enabled ) %}
+{%- if 'enabled' not in cron_settings or ( 'enabled' in cron_settings and cron_settings.enabled ) %}
   service.running:
     - name: {{ cron_settings.service }}
     - enable: True
-{% else %}
+{%- else %}
   service.dead:
     - name: {{ cron_settings.service }}
     - enable: False
-{% endif %}
+{%- endif %}

--- a/cron/service.sls
+++ b/cron/service.sls
@@ -5,11 +5,11 @@
 
 cron.service:
 {% if 'enabled' not in cron_settings or ( 'enabled' in cron_settings and cron_settings.enabled ) %}
-    service.running:
-        - name: {{ cron_settings.service }}
-        - enable: True
+  service.running:
+    - name: {{ cron_settings.service }}
+    - enable: True
 {% else %}
-    service.dead:
-        - name: {{ cron_settings.service }}
-        - enable: False
+  service.dead:
+    - name: {{ cron_settings.service }}
+    - enable: False
 {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -27,6 +27,7 @@ cron:
       comment: 'comment3'
     task4:
       type: 'present'  # run every 5 minutes
+      name: 'echo task4 > /tmp/test4'
       user: 'root'
       minute: '*/5'
       hour: '*'

--- a/pillar.example
+++ b/pillar.example
@@ -1,34 +1,34 @@
 cron:
-  enabled: True        # Default
-  lookup:              # Not needed, just if you want to use another cron program
-    pkg: 'cronie'
+  enabled: True      # Default
+  lookup:            # Not needed, just if you want to use another cron program
+    pkg: cronie
   tasks:
     task1:
-      type: 'present'  # Default
-      name: 'echo test > /tmp/test'
-      user: 'root'
+      type: present  # Default
+      name: echo test > /tmp/test
+      user: root
       minute: 0
       hour: 0
       daymonth: 7
       month: 1
       dayweek: 6
-      comment: 'comment1'
+      comment: comment1
     task2:
-      type: 'absent'   # To remove that crontask
-      name: 'echo task2 > /tmp/test2'
-      user: 'root'
-      minute: 'random'
+      type: absent   # To remove that crontask
+      name: echo task2 > /tmp/test2
+      user: root
+      minute: random
       hour: 1
     task3:
-      type: 'absent'
-      name: 'echo task3 > /tmp/test3'
-      user: 'root'
+      type: absent
+      name: echo task3 > /tmp/test3
+      user: root
       special: '@hourly'
-      comment: 'comment3'
+      comment: comment3
     task4:
-      type: 'present'  # run every 5 minutes
-      name: 'echo task4 > /tmp/test4'
-      user: 'root'
+      type: present  # run every 5 minutes
+      name: echo task4 > /tmp/test4
+      user: root
       minute: '*/5'
       hour: '*'
-      comment: 'comment4'
+      comment: comment4

--- a/pillar.example
+++ b/pillar.example
@@ -1,33 +1,33 @@
 cron:
-    enabled: True     # Default
-    lookup:           # Not needed, just if you want to use another cron program
-        pkg: 'cronie'
-    tasks:
-        task1:
-            type: 'present' # Default
-            name: 'echo test > /tmp/test'
-            user: 'root'
-            minute: 0
-            hour: 0
-            daymonth: 7
-            month: 1
-            dayweek: 6
-            comment: 'comment1'
-        task2:
-            type: 'absent' # To remove that crontask
-            name: 'echo task2 > /tmp/test2'
-            user: 'root'
-            minute: 'random'
-            hour: 1
-        task3:
-            type: 'absent'
-            name: 'echo task3 > /tmp/test3'
-            user: 'root'
-            special: '@hourly'
-            comment: 'comment3'
-        task4:
-            type: 'present' # run every 5 minutes
-            user: 'root'
-            minute: '*/5'
-            hour: '*'
-            comment: 'comment4'
+  enabled: True        # Default
+  lookup:              # Not needed, just if you want to use another cron program
+    pkg: 'cronie'
+  tasks:
+    task1:
+      type: 'present'  # Default
+      name: 'echo test > /tmp/test'
+      user: 'root'
+      minute: 0
+      hour: 0
+      daymonth: 7
+      month: 1
+      dayweek: 6
+      comment: 'comment1'
+    task2:
+      type: 'absent'   # To remove that crontask
+      name: 'echo task2 > /tmp/test2'
+      user: 'root'
+      minute: 'random'
+      hour: 1
+    task3:
+      type: 'absent'
+      name: 'echo task3 > /tmp/test3'
+      user: 'root'
+      special: '@hourly'
+      comment: 'comment3'
+    task4:
+      type: 'present'  # run every 5 minutes
+      user: 'root'
+      minute: '*/5'
+      hour: '*'
+      comment: 'comment4'


### PR DESCRIPTION
* fix(iteritems): replace with `items` instead
* style(whitespace): base on multiples of `2` rather than `4`
* style(jinja): use Jinja whitespace control

---

The first commit is required, the rest are based on improving the consistency of this formula, with reference to the general standards used for other formulas.